### PR TITLE
Convert domain_validation_options to a list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,12 +32,12 @@ resource "aws_acm_certificate" "wildcard" {
 
 resource "aws_route53_record" "cert_validation" {
   zone_id = data.aws_route53_zone.main.id
-  name    = aws_acm_certificate.main.domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.main.domain_validation_options[0].resource_record_type
+  name    = tolist(aws_acm_certificate.main.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.main.domain_validation_options)[0].resource_record_type
   ttl     = 60
 
   records = [
-    aws_acm_certificate.main.domain_validation_options[0].resource_record_value,
+    tolist(aws_acm_certificate.main.domain_validation_options)[0].resource_record_value,
   ]
 }
 


### PR DESCRIPTION
The AWS provider has been updated to v3.0, where domain_validation_options is now a set (previously a list).